### PR TITLE
Add S3 bucket with public access block configuration

### DIFF
--- a/s3_cloudfornt/main.tf
+++ b/s3_cloudfornt/main.tf
@@ -1,0 +1,12 @@
+
+terraform {
+  required_version = ">=1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.26.0"
+    }
+  }
+}
+
+provider "aws" {}

--- a/s3_cloudfornt/s3.tf
+++ b/s3_cloudfornt/s3.tf
@@ -1,0 +1,21 @@
+resource "aws_s3_bucket" "demo_bucket" {
+    # bucket 생성 시 bucket name 뒤 hash값이 붙어 이름을 유일하게 함. 
+    bucket_prefix = "demo-bucket"
+    # bucket  삭제 시 해당 bucket의 object까지 함께 정리
+    force_destroy = true
+}
+
+# s3 bucket의 public access 차단 - 보안강화
+resource "aws_s3_bucket_public_access_block" "block_public_access" {
+    bucket = aws_s3_bucket.demo_bucket.id
+
+    #  public ACL을 차단(bucket = private)
+    block_public_acls = true
+    # public policy 차단
+    block_public_policy = true
+    # public ACL 무시
+    ignore_public_acls = true
+    # 다른 public bucket과 함께 사용되지 않도록 제한
+    restrict_public_buckets = true
+}
+


### PR DESCRIPTION
- Created an S3 bucket using Terraform
- Added public access block to enhance security by denying public access

This ensures that the bucket is secure and prevents accidental public exposure of data.